### PR TITLE
Interop with EmberObject.extend on < 3.1

### DIFF
--- a/vendor/ember-modifier-manager-polyfill.js
+++ b/vendor/ember-modifier-manager-polyfill.js
@@ -22,7 +22,13 @@ import { deprecate } from '@ember/debug';
         return MODIFIER_MANAGERS.get(pointer);
       }
 
-      pointer = getPrototypeOf(pointer);
+      if (gte('3.1.0-beta.1')) {
+        pointer = getPrototypeOf(pointer);
+      } else if (Ember.Object.detect(pointer) && typeof pointer.superclass === 'function') {
+        pointer = pointer.superclass;
+      } else {
+        pointer = getPrototypeOf(pointer);
+      }
     }
 
     return;


### PR DESCRIPTION
I believe https://github.com/emberjs/ember.js/pull/16757 was what made it work on 3.1+.