### PR TITLE
fix ember-cli-version-checker error

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     this._super.init && this._super.init.apply(this, arguments);
 
     let checker = new VersionChecker(this.project);
-    let emberVersion = checker.forEmber();
+    let emberVersion = checker.for('ember-source');
 
     this.shouldPolyfillManager = emberVersion.lt('3.8.0-alpha.1');
     this.shouldPolyfillCapabilities = emberVersion.lt('3.13.0-beta.3');


### PR DESCRIPTION
'checker.forEmber' has been removed, please use 'checker.for(`ember-source`)'

```
- message: [ember-cli-version-checker] 'checker.forEmber' has been removed, please use 'checker.for(`ember-source`)'
  - name: Error
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: Error: [ember-cli-version-checker] 'checker.forEmber' has been removed, please use 'checker.for(`ember-source`)'
    at VersionChecker.forEmber (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\ember-modifier-manager-polyfill\node_modules\ember-cli-version-checker\src\version-checker.js:26:11)
    at Class.init (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\ember-modifier-manager-polyfill\index.js:12:32)
    at Class.superWrapper [as init] (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\core-object\lib\assign-properties.js:34:20)
    at new CoreObject (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\core-object\core-object.js:9:15)
    at new Class (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\core-object\core-object.js:21:5)
    at new Class (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\core-object\core-object.js:21:5)
    at graph.each (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\grdd\node_modules\ember-cli\lib\models\instantiate-addons.js:76:17)
    at Vertices.each (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\dag-map\dag-map.umd.js:197:13)
    at Vertices.walk (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\dag-map\dag-map.umd.js:125:14)
    at DAG.each (C:\Users\lifeart\Documents\repos\dreamcatcher-web-app\node_modules\dag-map\dag-map.umd.js:68:24)

```